### PR TITLE
Handle Driver Letter on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,5 +7,6 @@ const shims = Object.entries(pkg.dependencies)
   .map(([name, _]) => name.substr(prefix.length));
 
 module.exports = function all(rootUrl) {
-  return Object.fromEntries(shims.map(name => [name, new URL(`./node_modules/@frida/${name}`, rootUrl).pathname]));
+  const offset = process.platform === 'win32' ? 1 : 0;
+  return Object.fromEntries(shims.map(name => [name, new URL(`./node_modules/@frida/${name}`, rootUrl).pathname.substring(offset)]));
 };

--- a/index.js
+++ b/index.js
@@ -7,6 +7,6 @@ const shims = Object.entries(pkg.dependencies)
   .map(([name, _]) => name.substr(prefix.length));
 
 module.exports = function all(rootUrl) {
-  const offset = process.platform === 'win32' ? 1 : 0;
+  const offset = (process.platform === 'win32') ? 1 : 0;
   return Object.fromEntries(shims.map(name => [name, new URL(`./node_modules/@frida/${name}`, rootUrl).pathname.substring(offset)]));
 };


### PR DESCRIPTION
file:/// URL does not properly handle disk letter on Windows.
We must remove the beginning backslash to make the path valid

This patch might look very ugly. Better suggestions welcomed!